### PR TITLE
Kik's API seems to adhere to RFC 4648

### DIFF
--- a/lib/kik.rb
+++ b/lib/kik.rb
@@ -16,7 +16,7 @@ module Kik
 				body: body.to_json,
 				headers: {
 					'Content-Type' => 'application/json',
-					'Authorization' => "Basic #{Base64.encode64(auth)}"
+					'Authorization' => "Basic #{Base64.strict_encode64(auth)}"
 				},
 				debug_output: $stdout
 			})

--- a/lib/kik/version.rb
+++ b/lib/kik/version.rb
@@ -1,3 +1,3 @@
 module Kik
-  VERSION = "0.1.2"
+  VERSION = "0.1.3"
 end


### PR DESCRIPTION
Kik was rejecting my requests with an HTTP 401 Unauthorized error. I compared the request made by a successful curl with the request made by this library, and noticed some minor encoding differences in the Authorization header

Encoding the authorization token with `Base64.strict_encode64` solves the issue for me.